### PR TITLE
Testing/cache test

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -2,12 +2,21 @@ package cache
 
 import (
 	"context"
+	"os"
 
+	"github.com/go-redis/redis/v8"
 	"go.uber.org/fx"
 )
 
 var Module = fx.Module(
 	"cache",
+	fx.Supply(
+		&redis.Options{
+			Addr:     os.Getenv("REDIS_URL"),
+			Password: "", // no password set
+			DB:       0,  // use default DB
+		},
+	),
 	fx.Provide(
 		NewService,
 	),

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,0 +1,76 @@
+package cache_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/zinc-sig/webhook/pkg/cache"
+	"github.com/zinc-sig/webhook/pkg/mock"
+	"go.uber.org/fx"
+	"go.uber.org/fx/fxtest"
+)
+
+func TestLlen(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		app := fxtest.New(
+			t,
+			mock.ProvideMockCacheService(t),
+			fx.Invoke(
+				func(cache cache.Service) {
+					err := cache.Publish(t.Context(), "test", []byte("hello1"))
+					assert.NoError(t, err, "failed to publish message")
+
+					err = cache.Publish(t.Context(), "test", []byte("hello2"))
+					assert.NoError(t, err, "failed to publish message")
+
+					length, err := cache.Llen(t.Context(), "test")
+					assert.NoError(t, err, "failed to get list length")
+
+					assert.Equal(t, int64(2), length)
+				},
+			),
+		)
+
+		app.RequireStart()
+		t.Cleanup(app.RequireStop)
+	})
+}
+
+func TestLoadBalancePublish(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		app := fxtest.New(
+			t,
+			mock.ProvideMockCacheService(t),
+			fx.Invoke(
+				func(cache cache.Service) {
+					channels := []string{"channel1", "channel2", "channel3"}
+					err := cache.LoadBalancePublish(t.Context(), channels, []byte("hello1"))
+					assert.NoError(t, err, "failed to load balance publish")
+
+					err = cache.LoadBalancePublish(t.Context(), channels, []byte("hello2"))
+					assert.NoError(t, err, "failed to load balance publish")
+
+					err = cache.LoadBalancePublish(t.Context(), channels, []byte("hello3"))
+					assert.NoError(t, err, "failed to load balance publish")
+
+					// Check that messages are distributed across channels
+					length1, err := cache.Llen(t.Context(), "channel1")
+					assert.NoError(t, err, "failed to get list length for channel1")
+
+					length2, err := cache.Llen(t.Context(), "channel2")
+					assert.NoError(t, err, "failed to get list length for channel2")
+
+					length3, err := cache.Llen(t.Context(), "channel3")
+					assert.NoError(t, err, "failed to get list length for channel3")
+
+					assert.Equal(t, int64(1), length1)
+					assert.Equal(t, int64(1), length2)
+					assert.Equal(t, int64(1), length3)
+				},
+			),
+		)
+
+		app.RequireStart()
+		t.Cleanup(app.RequireStop)
+	})
+}

--- a/pkg/cache/service.go
+++ b/pkg/cache/service.go
@@ -5,12 +5,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
-	"os"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/go-redis/redis/v8"
+	"go.uber.org/fx"
 )
 
 type MessageHandler func(ctx context.Context, jobType string, payload json.RawMessage) error
@@ -53,18 +53,19 @@ type Service interface {
 	RegisterHandler(jobType string, handler MessageHandler)
 }
 
+type ServiceParams struct {
+	fx.In
+	Options *redis.Options
+}
+
 type service struct {
 	client   *redis.Client
 	locker   sync.Mutex
 	handlers map[string]MessageHandler
 }
 
-func NewService() Service {
-	client := redis.NewClient(&redis.Options{
-		Addr:     os.Getenv("REDIS_URL"),
-		Password: "", // no password set
-		DB:       0,  // use default DB
-	})
+func NewService(p ServiceParams) Service {
+	client := redis.NewClient(p.Options)
 	return &service{
 		client: client,
 	}

--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -4,12 +4,18 @@ import (
 	"context"
 	"crypto/rand"
 	"crypto/rsa"
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/go-redis/redis/v8"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/machinebox/graphql"
+	container "github.com/narwhl/mockestra/redis"
 	"github.com/stretchr/testify/mock"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/zinc-sig/webhook/pkg/cache"
+	"go.uber.org/fx"
 )
 
 type MockGraphQLClient struct {
@@ -20,6 +26,40 @@ type MockGraphQLClient struct {
 func (m *MockGraphQLClient) Run(ctx context.Context, req *graphql.Request, resp interface{}) error {
 	args := m.Called(ctx, req, resp)
 	return args.Error(0)
+}
+
+func ProvideMockCacheService(t *testing.T) fx.Option {
+	return fx.Options(
+		fx.NopLogger,
+		fx.Supply(
+			fx.Annotate(
+				"8-alpine",
+				fx.ResultTags(`name:"redis_version"`),
+			),
+		),
+		fx.Supply(fx.Annotate(
+			fmt.Sprintf("redis-test-%x", time.Now().Unix()),
+			fx.ResultTags(`name:"prefix"`),
+		)),
+		container.Module(),
+		fx.Provide(func(params struct {
+			fx.In
+			Container testcontainers.Container `name:"redis"`
+		}) *redis.Options {
+			endpoint, err := params.Container.PortEndpoint(t.Context(), container.Port, "")
+			if err != nil {
+				t.Errorf("failed to get endpoint: %v", err)
+			}
+			return &redis.Options{
+				Addr:     endpoint,
+				Password: "", // no password set
+				DB:       0,  // use default DB
+			}
+		}),
+		fx.Provide(
+			cache.NewService,
+		),
+	)
 }
 
 func generateTestToken(t *testing.T) (string, *rsa.PrivateKey) {


### PR DESCRIPTION
- Added testing on `Llen` and `LoadBalancePublish` on package cache.
- Changed signature on `cache.NewService` so that it now requires `*redis.Options`.
- Created function `ProvideMockCacheService(*testing.T)` that provides a mock `cache.Service` by returning a `fx.Option`