### PR TITLE
Changed logic on LoadBalancePublish for Redis cache

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -31,6 +31,11 @@ var Module = fx.Module(
 						return err
 					}
 					slog.Info("Processing job", "type", jobType, "queue", queue, "payload", data, "is_batch", len(data.Reports) > 1)
+
+					if err := cache.LoadBalanceDequeue(ctx, queue, len(data.Reports)); err != nil {
+						slog.Warn("Failed to load balance dequeue", "error", err)
+						return err
+					}
 					return nil
 				})
 				go cache.Subscribe(context.Background())

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,9 +1,11 @@
 package cache_test
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 
+	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
 	"github.com/zinc-sig/webhook/pkg/cache"
 	"github.com/zinc-sig/webhook/pkg/mock"
@@ -43,30 +45,26 @@ func TestLoadBalancePublish(t *testing.T) {
 			t,
 			mock.ProvideMockCacheService(t),
 			fx.Invoke(
-				func(cache cache.Service) {
+				func(cache cache.Service, client *redis.Client) {
+					jobs := []int{1, 3, 5, 1, 10, 1, 3}
 					channels := []string{"channel1", "channel2", "channel3"}
-					err := cache.LoadBalancePublish(t.Context(), channels, []byte("hello1"))
-					assert.NoError(t, err, "failed to load balance publish")
 
-					err = cache.LoadBalancePublish(t.Context(), channels, []byte("hello2"))
-					assert.NoError(t, err, "failed to load balance publish")
+					for idx, njobs := range jobs {
+						err := cache.LoadBalancePublish(t.Context(), channels, []byte(fmt.Sprintf("test%d", idx)), njobs)
+						assert.NoError(t, err, "failed to load balance publish")
+					}
 
-					err = cache.LoadBalancePublish(t.Context(), channels, []byte("hello3"))
-					assert.NoError(t, err, "failed to load balance publish")
+					expected := map[string][]string{
+						"channel1": {"test0", "test3", "test4"}, // 1+1+10 jobs
+						"channel2": {"test1", "test5", "test6"}, // 3+1+3 jobs
+						"channel3": {"test2"},                   // 5 jobs
+					}
 
-					// Check that messages are distributed across channels
-					length1, err := cache.Llen(t.Context(), "channel1")
-					assert.NoError(t, err, "failed to get list length for channel1")
-
-					length2, err := cache.Llen(t.Context(), "channel2")
-					assert.NoError(t, err, "failed to get list length for channel2")
-
-					length3, err := cache.Llen(t.Context(), "channel3")
-					assert.NoError(t, err, "failed to get list length for channel3")
-
-					assert.Equal(t, int64(1), length1)
-					assert.Equal(t, int64(1), length2)
-					assert.Equal(t, int64(1), length3)
+					for _, channel := range channels {
+						content, err := client.LRange(t.Context(), channel, 0, -1).Result()
+						assert.NoError(t, err, "failed to read channel content")
+						assert.ElementsMatchf(t, content, expected[channel], "channel content does not match for channel %s", channel)
+					}
 				},
 			),
 		)
@@ -80,7 +78,7 @@ func TestLoadBalancePublish(t *testing.T) {
 			t,
 			mock.ProvideMockCacheService(t),
 			fx.Invoke(
-				func(cache cache.Service) {
+				func(cache cache.Service, client *redis.Client) {
 					var wg sync.WaitGroup
 
 					channels := []string{"channel1", "channel2", "channel3"}
@@ -88,26 +86,72 @@ func TestLoadBalancePublish(t *testing.T) {
 						wg.Add(1)
 						go func() {
 							defer wg.Done()
-							err := cache.LoadBalancePublish(t.Context(), channels, []byte("hello"))
+							err := cache.LoadBalancePublish(t.Context(), channels, []byte("hello"), 3)
 							assert.NoError(t, err, "failed to load balance publish")
 						}()
 					}
 					wg.Wait()
 
 					// Check that messages are distributed across channels
-					length1, err := cache.Llen(t.Context(), "channel1")
+					length1, err := client.LLen(t.Context(), "channel1").Result()
 					assert.NoError(t, err, "failed to get list length for channel1")
 
-					length2, err := cache.Llen(t.Context(), "channel2")
+					length2, err := client.LLen(t.Context(), "channel2").Result()
 					assert.NoError(t, err, "failed to get list length for channel2")
 
-					length3, err := cache.Llen(t.Context(), "channel3")
+					length3, err := client.LLen(t.Context(), "channel3").Result()
 					assert.NoError(t, err, "failed to get list length for channel3")
 
 					assert.Equal(t, int64(33), length1)
 					assert.Equal(t, int64(33), length2)
 					assert.Equal(t, int64(33), length3)
 
+				},
+			),
+		)
+
+		app.RequireStart()
+		t.Cleanup(app.RequireStop)
+	})
+}
+
+func TestLoadBalanceDequeue(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		app := fxtest.New(
+			t,
+			mock.ProvideMockCacheService(t),
+			fx.Invoke(
+				func(cache cache.Service, client *redis.Client) {
+					channels := []string{"channel1", "channel2", "channel3"}
+
+					// Pre-fill channels with lengths
+					for i, channel := range channels {
+						err := client.Set(t.Context(), fmt.Sprintf("%s:length", channel), (i+1)*10, 0).Err()
+						assert.NoError(t, err, "failed to set initial length")
+					}
+
+					// Dequeue jobs
+					err := cache.LoadBalanceDequeue(t.Context(), "channel1", 5)
+					assert.NoError(t, err, "failed to load balance dequeue")
+
+					err = cache.LoadBalanceDequeue(t.Context(), "channel2", 15)
+					assert.NoError(t, err, "failed to load balance dequeue")
+
+					err = cache.LoadBalanceDequeue(t.Context(), "channel3", 8)
+					assert.NoError(t, err, "failed to load balance dequeue")
+
+					// Check final lengths
+					length1, err := client.Get(t.Context(), "channel1:length").Int()
+					assert.NoError(t, err, "failed to get length for channel1")
+					assert.Equal(t, 5, length1)
+
+					length2, err := client.Get(t.Context(), "channel2:length").Int()
+					assert.NoError(t, err, "failed to get length for channel2")
+					assert.Equal(t, 5, length2)
+
+					length3, err := client.Get(t.Context(), "channel3:length").Int()
+					assert.NoError(t, err, "failed to get length for channel3")
+					assert.Equal(t, 22, length3)
 				},
 			),
 		)

--- a/pkg/cache/service.go
+++ b/pkg/cache/service.go
@@ -54,7 +54,8 @@ type Service interface {
 	Read(ctx context.Context, key string) ([]byte, error)
 	Remove(ctx context.Context, key string) error
 	Publish(ctx context.Context, channel string, message []byte) error
-	LoadBalancePublish(ctx context.Context, channels []string, message []byte) error
+	LoadBalancePublish(ctx context.Context, channels []string, message []byte, njobs int) error
+	LoadBalanceDequeue(ctx context.Context, channel string, njobs int) error
 	Llen(ctx context.Context, channel string) (int64, error)
 	Subscribe(ctx context.Context) error
 	RegisterHandler(jobType string, handler MessageHandler)
@@ -121,17 +122,19 @@ func (s *service) Publish(ctx context.Context, channel string, message []byte) e
 	return s.client.RPush(ctx, channel, message).Err()
 }
 
-func (s *service) LoadBalancePublish(ctx context.Context, channels []string, message []byte) error {
+func (s *service) LoadBalancePublish(ctx context.Context, channels []string, message []byte, njobs int) error {
 
 	s.locker.Lock()
 	defer s.locker.Unlock()
 
 	// Find the channel with the least number of messages
 	var targetChannel string
-	minLen := int64(-1)
+	minLen := -1
 	for _, channel := range channels {
-		length, err := s.Llen(ctx, channel)
-		if err != nil {
+		length, err := s.client.Get(ctx, fmt.Sprintf("%s:length", channel)).Int()
+		if err == redis.Nil {
+			length = 0 // Channel does not exist, treat as empty
+		} else if err != nil {
 			slog.Warn("Failed to get length of channel", "channel", channel, "error", err)
 			continue
 		}
@@ -145,7 +148,34 @@ func (s *service) LoadBalancePublish(ctx context.Context, channels []string, mes
 		return fmt.Errorf("failed to determine target channel for load balancing")
 	}
 	slog.Info("Publishing to channel: %s with %d messages", "channel", targetChannel, "length", minLen)
-	return s.client.RPush(ctx, targetChannel, message).Err()
+
+	pipe := s.client.TxPipeline()
+	pipe.RPush(ctx, targetChannel, message)
+	pipe.IncrBy(ctx, fmt.Sprintf("%s:length", targetChannel), int64(njobs))
+
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+func (s *service) LoadBalanceDequeue(ctx context.Context, channel string, njobs int) error {
+	s.locker.Lock()
+	defer s.locker.Unlock()
+
+	err := s.client.DecrBy(ctx, fmt.Sprintf("%s:length", channel), int64(njobs)).Err()
+	if err != nil {
+		return err
+	}
+
+	curr_len, err := s.client.Get(ctx, fmt.Sprintf("%s:length", channel)).Int()
+	if err != nil {
+		return err
+	}
+	if curr_len < 0 {
+		// Reset to zero if it goes negative
+		slog.Warn("Channel length went negative, resetting to zero", "channel", channel)
+		return s.client.Set(ctx, fmt.Sprintf("%s:length", channel), 0, 0).Err()
+	}
+	return nil
 }
 
 func (s *service) Subscribe(ctx context.Context) error {

--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -8,12 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-redis/redis/v8"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/machinebox/graphql"
 	container "github.com/narwhl/mockestra/redis"
 	"github.com/stretchr/testify/mock"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/zinc-sig/webhook/pkg/cache"
+	"github.com/zinc-sig/webhook/pkg/repository"
 	"go.uber.org/fx"
 )
 
@@ -25,6 +27,122 @@ type MockGraphQLClient struct {
 func (m *MockGraphQLClient) Run(ctx context.Context, req *graphql.Request, resp interface{}) error {
 	args := m.Called(ctx, req, resp)
 	return args.Error(0)
+}
+
+type MockRepository struct {
+	mock.Mock
+}
+
+func (m *MockRepository) GetUser(ctx context.Context, itsc, name string) (*repository.User, error) {
+	args := m.Called(ctx, itsc, name)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*repository.User), args.Error(1)
+}
+
+func (m *MockRepository) UpdateExtractedSubmissionEntry(ctx context.Context, id int, extractedPath, failReason string) error {
+	args := m.Called(ctx, id, extractedPath, failReason)
+	return args.Error(0)
+}
+
+func (m *MockRepository) AddCourse(ctx context.Context, code string, semesterID int, title string) (int, error) {
+	args := m.Called(ctx, code, semesterID, title)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockRepository) AddSections(ctx context.Context, courseID int, sectionNames []string) (map[string]int, error) {
+	args := m.Called(ctx, courseID, sectionNames)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[string]int), args.Error(1)
+}
+
+func (m *MockRepository) AddStudentsToCourseSection(ctx context.Context, studentUserIDs []int, sectionID int) error {
+	args := m.Called(ctx, studentUserIDs, sectionID)
+	return args.Error(0)
+}
+
+func (m *MockRepository) AddStudentsToCourse(ctx context.Context, studentUserIDs []int, courseID int) error {
+	args := m.Called(ctx, studentUserIDs, courseID)
+	return args.Error(0)
+}
+
+func (m *MockRepository) RemoveStudentsFromCourse(ctx context.Context, courseID int) error {
+	args := m.Called(ctx, courseID)
+	return args.Error(0)
+}
+
+func (m *MockRepository) RemoveStudentsFromSection(ctx context.Context, sectionID int) error {
+	args := m.Called(ctx, sectionID)
+	return args.Error(0)
+}
+
+func (m *MockRepository) GetStudentUserIds(ctx context.Context, itscIDs []string) ([]int, error) {
+	args := m.Called(ctx, itscIDs)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]int), args.Error(1)
+}
+
+func (m *MockRepository) CreateSemesterIfNotExist(ctx context.Context, id int) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *MockRepository) GetStudentCourseEnrollmentMap(courseCode string) (*repository.EnrollmentMap, error) {
+	args := m.Called(courseCode)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*repository.EnrollmentMap), args.Error(1)
+}
+
+func (m *MockRepository) UpdateReportEntry(ctx context.Context, report map[string]interface{}) error {
+	args := m.Called(ctx, report)
+	return args.Error(0)
+}
+
+func (m *MockRepository) GetGradingSubmissions(ctx context.Context, assignmentConfigID int) (*repository.Assignment, error) {
+	args := m.Called(ctx, assignmentConfigID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*repository.Assignment), args.Error(1)
+}
+
+func (m *MockRepository) GetLatestOrSelectedSubmissions(ctx context.Context, assignmentConfigID int, selectedSubmissionIDs []int) ([]repository.Submission, error) {
+	args := m.Called(ctx, assignmentConfigID, selectedSubmissionIDs)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]repository.Submission), args.Error(1)
+}
+
+func (m *MockRepository) ExtractZip(submissionID int, storedName string) error {
+	args := m.Called(submissionID, storedName)
+	return args.Error(0)
+}
+
+func (m *MockRepository) GetGradingPolicy(ctx context.Context, assignmentConfigID, userID int) (bool, bool, error) {
+	args := m.Called(ctx, assignmentConfigID, userID)
+	return args.Bool(0), args.Bool(1), args.Error(2)
+}
+
+func ProvideMockRepository(t *testing.T) fx.Option {
+	mockRepo := new(MockRepository)
+	return fx.Options(
+		fx.NopLogger,
+		fx.Supply(mockRepo),
+		fx.Supply(
+			fx.Annotate(
+				mockRepo,
+				fx.As(new(repository.Repository)),
+			),
+		),
+	)
 }
 
 func ProvideMockCacheService(t *testing.T) fx.Option {
@@ -53,8 +171,22 @@ func ProvideMockCacheService(t *testing.T) fx.Option {
 				DSN: endpoint,
 			}
 		}),
+		// Cache Service
 		fx.Provide(
 			cache.NewService,
+		),
+		// Redis Client
+		fx.Provide(
+			func(p struct {
+				fx.In
+				Config *cache.Config
+			}) *redis.Client {
+				return redis.NewClient(&redis.Options{
+					Addr:     p.Config.DSN, // e.g., "localhost:6379"
+					Password: "",           // no password set
+					DB:       0,            // use default DB
+				})
+			},
 		),
 	)
 }

--- a/pkg/trigger/service.go
+++ b/pkg/trigger/service.go
@@ -57,21 +57,21 @@ func (s *service) buildGradingJobPayload(jobType string, gradingPayloads []Gradi
 		"assignment_config_id": assignmentConfigID,
 		"isTest":               isTest,
 	}
-	
+
 	// Add optional initiatedBy field if provided
 	if initiatedBy != nil {
 		payloadMap["initiatedBy"] = *initiatedBy
 	} else {
 		payloadMap["initiatedBy"] = nil
 	}
-	
+
 	// Marshal the payload
 	payload, err := json.Marshal(payloadMap)
 	if err != nil {
 		slog.Warn("Failed to marshal grading payload", "error", err)
 		return nil, fmt.Errorf("failed to marshal grading payload: %s", err.Error())
 	}
-	
+
 	// Create the job wrapper
 	job, err := json.Marshal(map[string]interface{}{
 		"job":     jobType,
@@ -81,7 +81,7 @@ func (s *service) buildGradingJobPayload(jobType string, gradingPayloads []Gradi
 		slog.Warn("Failed to marshal job payload", "error", err)
 		return nil, fmt.Errorf("failed to marshal job payload: %s", err.Error())
 	}
-	
+
 	return job, nil
 }
 
@@ -207,7 +207,7 @@ func (s *service) DecompressSubmission(ctx context.Context, payload json.RawMess
 				CreatedAt:     submission.CreatedAt.Time(),
 			},
 		}
-		
+
 		job, err := s.buildGradingJobPayload("gradingTask", gradingPayloads, submission.AssignmentConfigID, isTest, nil)
 		if err != nil {
 			return err
@@ -225,7 +225,7 @@ func (s *service) DecompressSubmission(ctx context.Context, payload json.RawMess
 			queues = append(queues, fmt.Sprintf("%s:grader", queue))
 		}
 		slog.Info("sending job payload", "payload", string(job))
-		if err := s.cache.LoadBalancePublish(ctx, queues, job); err != nil {
+		if err := s.cache.LoadBalancePublish(ctx, queues, job, len(gradingPayloads)); err != nil {
 			slog.Warn("Failed to publish grading payload", "error", err)
 			return fmt.Errorf("failed to publish grading payload: %s", err.Error())
 		}
@@ -360,7 +360,7 @@ func (s *service) ManualGradingTask(ctx context.Context, assignmentConfigId int,
 		queues = append(queues, fmt.Sprintf("%s:grader", queue))
 	}
 	slog.Info("sending job payload", "payload", string(jsonPayload))
-	if err := s.cache.LoadBalancePublish(ctx, queues, jsonPayload); err != nil {
+	if err := s.cache.LoadBalancePublish(ctx, queues, jsonPayload, len(gradingPayloads)); err != nil {
 		slog.Warn("Failed to publish grading payload", "error", err)
 		return fmt.Errorf("failed to publish grading payload: %s", err.Error())
 	}
@@ -402,7 +402,7 @@ func (s *service) GradingTask(ctx context.Context, payload *GradingTaskRequest) 
 			queues = append(queues, fmt.Sprintf("%s:grader", queue))
 		}
 		slog.Info("sending job payload", "payload", string(jsonPayload))
-		if err := s.cache.LoadBalancePublish(ctx, queues, jsonPayload); err != nil {
+		if err := s.cache.LoadBalancePublish(ctx, queues, jsonPayload, len(gradingPayloads)); err != nil {
 			slog.Warn("Failed to publish grading payload", "error", err)
 			return fmt.Errorf("failed to publish grading payload: %s", err.Error())
 		}

--- a/pkg/user/handler_test.go
+++ b/pkg/user/handler_test.go
@@ -47,8 +47,13 @@ func (m *MockCache) Publish(ctx context.Context, channel string, message []byte)
 	return args.Error(0)
 }
 
-func (m *MockCache) LoadBalancePublish(ctx context.Context, channels []string, message []byte) error {
-	args := m.Called(ctx, channels, message)
+func (m *MockCache) LoadBalancePublish(ctx context.Context, channels []string, message []byte, njobs int) error {
+	args := m.Called(ctx, channels, message, njobs)
+	return args.Error(0)
+}
+
+func (m *MockCache) LoadBalanceDequeue(ctx context.Context, channel string, njobs int) error {
+	args := m.Called(ctx, channel, njobs)
 	return args.Error(0)
 }
 


### PR DESCRIPTION
- Modified logic on `LoadBalancePublish` function on cache.Service, it is now used on another separate key on Redis `<channel>:length` to store the load (i.e. the number of grading tasks allocated) of the grader.
- Added function `LoadBalanceDequeue`, which is called when the grader finishes its grading. Its functionality is to decrement the stored number of grading tasks allocated to the respective grader.