### PR TITLE
feat(ci): allow overriding workflow condition for publishing containe…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
 
   build-and-push-image:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.base_ref == 'main')
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' || (github.event_name == 'pull_request' && github.base_ref == 'main') || github.event.inputs.produce_container_image == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request updates the build workflow to make container image production more flexible. Now, the build-and-push-image job can be triggered manually through a workflow input, in addition to the existing automatic triggers.

Workflow improvements:

* Updated the `build-and-push-image` job in `.github/workflows/build.yml` to allow triggering the container image build when the workflow input `produce_container_image` is set to `'true'`, making it possible to manually produce container images as needed.