### PR TITLE
Test on load balance between webhook & graders

### DIFF
--- a/justfile
+++ b/justfile
@@ -6,3 +6,6 @@ run:
 
 test:
   go test ./...
+
+test-integration:
+  go test ./pkg/cache -integration

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -37,11 +37,11 @@ var Module = fx.Module(
 					}
 					slog.Info("Processing job", "type", jobType, "queue", queue, "payload", data, "is_batch", len(data.Reports) > 1)
 
-          if err := cache.LoadBalanceDequeue(ctx, queue, len(data.Reports)); err != nil {
+					if err := cache.LoadBalanceDequeue(ctx, queue, len(data.Reports)); err != nil {
 						slog.Warn("Failed to load balance dequeue", "error", err)
 						return err
 					}
-					
+
 					// Log successful processing
 					var reportIDs []int
 					for _, report := range data.Reports {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -24,7 +24,7 @@ var Module = fx.Module(
 	fx.Invoke(func(lifecycle fx.Lifecycle, cache Service) {
 		lifecycle.Append(fx.Hook{
 			OnStart: func(ctx context.Context) error {
-				cache.RegisterHandler("doneGrading", func(ctx context.Context, jobType, queue string, payload json.RawMessage) error {
+				cache.RegisterHandler("doneGrading", func(ctx context.Context, jobType, channel string, payload json.RawMessage) error {
 					var payloadJson string
 					if err := json.Unmarshal(payload, &payloadJson); err != nil {
 						slog.Warn("Failed to unmarshal payload", "error", err)
@@ -35,9 +35,9 @@ var Module = fx.Module(
 						slog.Warn("Failed to unmarshal payload", "error", err)
 						return err
 					}
-					slog.Info("Processing job", "type", jobType, "queue", queue, "payload", data, "is_batch", len(data.Reports) > 1)
+					slog.Info("Processing job", "type", jobType, "channel", channel, "payload", data, "is_batch", len(data.Reports) > 1)
 
-					if err := cache.LoadBalanceDequeue(ctx, queue, len(data.Reports)); err != nil {
+					if err := cache.LoadBalanceGraderDequeue(ctx, channel, len(data.Reports)); err != nil {
 						slog.Warn("Failed to load balance dequeue", "error", err)
 						return err
 					}
@@ -47,7 +47,7 @@ var Module = fx.Module(
 					for _, report := range data.Reports {
 						reportIDs = append(reportIDs, report.ID)
 					}
-					slog.Info("doneGrading processed successfully", "reportIDs", reportIDs, "reportCount", len(data.Reports), "queue", queue)
+					slog.Info("doneGrading processed successfully", "reportIDs", reportIDs, "reportCount", len(data.Reports), "channel", channel)
 
 					return nil
 				})

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -31,6 +31,11 @@ var Module = fx.Module(
 						return err
 					}
 					slog.Info("Processing job", "type", jobType, "queue", queue, "payload", data, "is_batch", len(data.Reports) > 1)
+
+					if err := cache.LoadBalanceDequeue(ctx, queue, len(data.Reports)); err != nil {
+						slog.Warn("Failed to load balance dequeue", "error", err)
+						return err
+					}
 					return nil
 				})
 				go cache.Subscribe(context.Background())

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,9 +1,11 @@
 package cache_test
 
 import (
+	"fmt"
 	"sync"
 	"testing"
 
+	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
 	"github.com/zinc-sig/webhook/pkg/cache"
 	"github.com/zinc-sig/webhook/pkg/mock"
@@ -43,30 +45,26 @@ func TestLoadBalancePublish(t *testing.T) {
 			t,
 			mock.ProvideMockCacheService(t),
 			fx.Invoke(
-				func(cache cache.Service) {
+				func(cache cache.Service, client *redis.Client) {
+					jobs := []int{1, 3, 5, 1, 10, 1, 3}
 					channels := []string{"channel1", "channel2", "channel3"}
-					err := cache.LoadBalancePublish(t.Context(), channels, []byte("hello1"))
-					assert.NoError(t, err, "failed to load balance publish")
 
-					err = cache.LoadBalancePublish(t.Context(), channels, []byte("hello2"))
-					assert.NoError(t, err, "failed to load balance publish")
+					for idx, njobs := range jobs {
+						err := cache.LoadBalancePublish(t.Context(), channels, []byte(fmt.Sprintf("test%d", idx)), njobs)
+						assert.NoError(t, err, "failed to load balance publish")
+					}
 
-					err = cache.LoadBalancePublish(t.Context(), channels, []byte("hello3"))
-					assert.NoError(t, err, "failed to load balance publish")
+					expected := map[string][]string{
+						"channel1": {"test0", "test3", "test4"}, // 1+1+10 jobs
+						"channel2": {"test1", "test5", "test6"}, // 3+1+3 jobs
+						"channel3": {"test2"},                   // 5 jobs
+					}
 
-					// Check that messages are distributed across channels
-					length1, err := cache.Llen(t.Context(), "channel1")
-					assert.NoError(t, err, "failed to get list length for channel1")
-
-					length2, err := cache.Llen(t.Context(), "channel2")
-					assert.NoError(t, err, "failed to get list length for channel2")
-
-					length3, err := cache.Llen(t.Context(), "channel3")
-					assert.NoError(t, err, "failed to get list length for channel3")
-
-					assert.Equal(t, int64(1), length1)
-					assert.Equal(t, int64(1), length2)
-					assert.Equal(t, int64(1), length3)
+					for _, channel := range channels {
+						content, err := client.LRange(t.Context(), channel, 0, -1).Result()
+						assert.NoError(t, err, "failed to read channel content")
+						assert.ElementsMatchf(t, content, expected[channel], "channel content does not match for channel %s", channel)
+					}
 				},
 			),
 		)
@@ -80,7 +78,7 @@ func TestLoadBalancePublish(t *testing.T) {
 			t,
 			mock.ProvideMockCacheService(t),
 			fx.Invoke(
-				func(cache cache.Service) {
+				func(cache cache.Service, client *redis.Client) {
 					var wg sync.WaitGroup
 
 					channels := []string{"channel1", "channel2", "channel3"}
@@ -88,26 +86,72 @@ func TestLoadBalancePublish(t *testing.T) {
 						wg.Add(1)
 						go func() {
 							defer wg.Done()
-							err := cache.LoadBalancePublish(t.Context(), channels, []byte("hello"))
+							err := cache.LoadBalancePublish(t.Context(), channels, []byte("hello"), 3)
 							assert.NoError(t, err, "failed to load balance publish")
 						}()
 					}
 					wg.Wait()
 
 					// Check that messages are distributed across channels
-					length1, err := cache.Llen(t.Context(), "channel1")
+					length1, err := client.LLen(t.Context(), "channel1").Result()
 					assert.NoError(t, err, "failed to get list length for channel1")
 
-					length2, err := cache.Llen(t.Context(), "channel2")
+					length2, err := client.LLen(t.Context(), "channel2").Result()
 					assert.NoError(t, err, "failed to get list length for channel2")
 
-					length3, err := cache.Llen(t.Context(), "channel3")
+					length3, err := client.LLen(t.Context(), "channel3").Result()
 					assert.NoError(t, err, "failed to get list length for channel3")
 
 					assert.Equal(t, int64(33), length1)
 					assert.Equal(t, int64(33), length2)
 					assert.Equal(t, int64(33), length3)
 
+				},
+			),
+		)
+
+		app.RequireStart()
+		t.Cleanup(app.RequireStop)
+	})
+}
+
+func TestLoadBalanceDequeue(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		app := fxtest.New(
+			t,
+			mock.ProvideMockCacheService(t),
+			fx.Invoke(
+				func(cache cache.Service, client *redis.Client) {
+					channels := []string{"channel1", "channel2", "channel3"}
+
+					// Pre-fill channels with lengths
+					for i, channel := range channels {
+						err := client.Set(t.Context(), fmt.Sprintf("%s:length", channel), (i+1)*10, 0).Err()
+						assert.NoError(t, err, "failed to set initial length")
+					}
+
+					// Dequeue jobs
+					err := cache.LoadBalanceDequeue(t.Context(), "channel1", 5)
+					assert.NoError(t, err, "failed to load balance dequeue")
+
+					err = cache.LoadBalanceDequeue(t.Context(), "channel2", 15)
+					assert.NoError(t, err, "failed to load balance dequeue")
+
+					err = cache.LoadBalanceDequeue(t.Context(), "channel3", 8)
+					assert.NoError(t, err, "failed to load balance dequeue")
+
+					// Check final lengths
+					length1, err := client.Get(t.Context(), "channel1:length").Int()
+					assert.NoError(t, err, "failed to get length for channel1")
+					assert.Equal(t, 5, length1)
+
+					length2, err := client.Get(t.Context(), "channel2:length").Int()
+					assert.NoError(t, err, "failed to get length for channel2")
+					assert.Equal(t, 5, length2)
+
+					length3, err := client.Get(t.Context(), "channel3:length").Int()
+					assert.NoError(t, err, "failed to get length for channel3")
+					assert.Equal(t, 22, length3)
 				},
 			),
 		)

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -3,8 +3,10 @@ package cache_test
 import (
 	"context"
 	"encoding/json"
+	"flag"
 	"fmt"
 	"log/slog"
+	"math/rand"
 	"strings"
 	"sync"
 	"testing"
@@ -14,9 +16,17 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/zinc-sig/webhook/pkg/cache"
 	"github.com/zinc-sig/webhook/pkg/mock"
+	"github.com/zinc-sig/webhook/pkg/trigger"
 	"go.uber.org/fx"
 	"go.uber.org/fx/fxtest"
 )
+
+var runIntegrationTests = flag.Bool("integration", false, "set to true to run integration tests")
+
+func TestMain(m *testing.M) {
+	flag.Parse()
+	m.Run()
+}
 
 func TestLlen(t *testing.T) {
 	t.Run("success", func(t *testing.T) {
@@ -50,12 +60,13 @@ func TestLoadBalancePublish(t *testing.T) {
 			t,
 			mock.ProvideMockCacheService(t),
 			fx.Invoke(
-				func(cache cache.Service, client *redis.Client) {
+				func(s cache.Service, client *redis.Client) {
 					jobs := []int{1, 3, 5, 1, 10, 1, 3}
 					channels := []string{"channel1", "channel2", "channel3"}
+					s.Put(t.Context(), cache.QueueKey, []byte(strings.Join(channels, ",")), 0)
 
 					for idx, njobs := range jobs {
-						err := cache.LoadBalancePublish(t.Context(), channels, []byte(fmt.Sprintf("test%d", idx)), njobs)
+						err := s.LoadBalanceGraderPublish(t.Context(), []byte(fmt.Sprintf("test%d", idx)), njobs)
 						assert.NoError(t, err, "failed to load balance publish")
 					}
 
@@ -66,7 +77,7 @@ func TestLoadBalancePublish(t *testing.T) {
 					}
 
 					for _, channel := range channels {
-						content, err := client.LRange(t.Context(), channel, 0, -1).Result()
+						content, err := client.LRange(t.Context(), fmt.Sprintf("%s:grader", channel), 0, -1).Result()
 						assert.NoError(t, err, "failed to read channel content")
 						assert.ElementsMatchf(t, content, expected[channel], "channel content does not match for channel %s", channel)
 					}
@@ -83,29 +94,31 @@ func TestLoadBalancePublish(t *testing.T) {
 			t,
 			mock.ProvideMockCacheService(t),
 			fx.Invoke(
-				func(cache cache.Service, client *redis.Client) {
+				func(s cache.Service, client *redis.Client) {
 					var wg sync.WaitGroup
 
 					channels := []string{"channel1", "channel2", "channel3"}
+					s.Put(t.Context(), cache.QueueKey, []byte(strings.Join(channels, ",")), 0)
+
 					for range 99 {
 						wg.Add(1)
 						go func() {
 							defer wg.Done()
-							err := cache.LoadBalancePublish(t.Context(), channels, []byte("hello"), 3)
+							err := s.LoadBalanceGraderPublish(t.Context(), []byte("hello"), 3)
 							assert.NoError(t, err, "failed to load balance publish")
 						}()
 					}
 					wg.Wait()
 
 					// Check that messages are distributed across channels
-					length1, err := client.LLen(t.Context(), "channel1").Result()
-					assert.NoError(t, err, "failed to get list length for channel1")
+					length1, err := client.LLen(t.Context(), "channel1:grader").Result()
+					assert.NoError(t, err, "failed to get list length for channel1:grader")
 
-					length2, err := client.LLen(t.Context(), "channel2").Result()
-					assert.NoError(t, err, "failed to get list length for channel2")
+					length2, err := client.LLen(t.Context(), "channel2:grader").Result()
+					assert.NoError(t, err, "failed to get list length for channel2:grader")
 
-					length3, err := client.LLen(t.Context(), "channel3").Result()
-					assert.NoError(t, err, "failed to get list length for channel3")
+					length3, err := client.LLen(t.Context(), "channel3:grader").Result()
+					assert.NoError(t, err, "failed to get list length for channel3:grader")
 
 					assert.Equal(t, int64(33), length1)
 					assert.Equal(t, int64(33), length2)
@@ -126,8 +139,9 @@ func TestLoadBalanceDequeue(t *testing.T) {
 			t,
 			mock.ProvideMockCacheService(t),
 			fx.Invoke(
-				func(cache cache.Service, client *redis.Client) {
+				func(s cache.Service, client *redis.Client) {
 					channels := []string{"channel1", "channel2", "channel3"}
+					s.Put(t.Context(), cache.QueueKey, []byte(strings.Join(channels, ",")), 0)
 
 					// Pre-fill channels with lengths
 					for i, channel := range channels {
@@ -136,13 +150,13 @@ func TestLoadBalanceDequeue(t *testing.T) {
 					}
 
 					// Dequeue jobs
-					err := cache.LoadBalanceDequeue(t.Context(), "channel1", 5)
+					err := s.LoadBalanceGraderDequeue(t.Context(), "channel1", 5)
 					assert.NoError(t, err, "failed to load balance dequeue")
 
-					err = cache.LoadBalanceDequeue(t.Context(), "channel2", 15)
+					err = s.LoadBalanceGraderDequeue(t.Context(), "channel2", 15)
 					assert.NoError(t, err, "failed to load balance dequeue")
 
-					err = cache.LoadBalanceDequeue(t.Context(), "channel3", 8)
+					err = s.LoadBalanceGraderDequeue(t.Context(), "channel3", 8)
 					assert.NoError(t, err, "failed to load balance dequeue")
 
 					// Check final lengths
@@ -166,7 +180,7 @@ func TestLoadBalanceDequeue(t *testing.T) {
 	})
 }
 
-func TestLoadBalanceIntegration(t *testing.T) {
+func TestLoadBalance(t *testing.T) {
 	t.Run("publish and dequeue", func(t *testing.T) {
 		app := fxtest.New(
 			t,
@@ -189,7 +203,7 @@ func TestLoadBalanceIntegration(t *testing.T) {
 						}
 						slog.Info("Processing job", "type", jobType, "queue", queue, "payload", data, "is_batch", len(data.Reports) > 1)
 
-						if err := s.LoadBalanceDequeue(ctx, queue, len(data.Reports)); err != nil {
+						if err := s.LoadBalanceGraderDequeue(ctx, queue, len(data.Reports)); err != nil {
 							slog.Warn("Failed to load balance dequeue", "error", err)
 							return err
 						}
@@ -208,7 +222,7 @@ func TestLoadBalanceIntegration(t *testing.T) {
 
 					// Publish jobs
 					for i := range 30 {
-						err := s.LoadBalancePublish(t.Context(), channels, []byte(fmt.Sprintf("job%d", i)), 1)
+						err := s.LoadBalanceGraderPublish(t.Context(), []byte(fmt.Sprintf("job%d", i)), 1)
 						assert.NoError(t, err, "failed to load balance publish")
 					}
 
@@ -258,4 +272,167 @@ func TestLoadBalanceIntegration(t *testing.T) {
 		app.RequireStart()
 		t.Cleanup(app.RequireStop)
 	})
+}
+
+func TestLoadBalanceIntegration(t *testing.T) {
+	t.Run("publish and dequeue", func(t *testing.T) {
+
+		if !*runIntegrationTests {
+			t.Skip("Skipping integration test; use -integration flag to run")
+		}
+
+		wg := sync.WaitGroup{}
+
+		app := fxtest.New(
+			t,
+			cache.Module,
+			fx.Supply(
+				&cache.Config{
+					DSN: "10.35.53.115:21862",
+				},
+			),
+			fx.Invoke(
+				func(lifecycle fx.Lifecycle, s cache.Service, p cache.ServiceParams) {
+					lifecycle.Append(fx.Hook{
+						OnStart: func(ctx context.Context) error {
+							const testID = 1
+
+							client := redis.NewClient(&redis.Options{
+								Addr:     p.Config.DSN, // e.g., "localhost:6379"
+								Password: "",           // no password set
+								DB:       0,            // use default DB
+							})
+
+							data, err := s.Read(t.Context(), cache.QueueKey)
+							assert.NoError(t, err, "failed to read grader queues")
+							assert.NotNil(t, data, "grader queues data is nil")
+
+							// Channels of grader (e.g. ["channel1", "channel2", "channel3"])
+							channels := strings.Split(string(data), ",")
+
+							slog.Info("Grader Channels: %v\n", "channels", channels)
+
+							initQueueLengths := make(map[string]int)
+							// Check initial lengths
+							for _, channel := range channels {
+								length, err := client.Get(t.Context(), fmt.Sprintf("%s:length", channel)).Int()
+								if err == redis.Nil {
+									length = 0 // Channel does not exist, treat as empty
+								} else if err != nil {
+									slog.Warn("Failed to get length of channel", "channel", channel, "error", err)
+									continue
+								}
+
+								initQueueLengths[channel] = length
+							}
+
+							slog.Info("Initial Queue Lengths: %v\n", "initQueueLengths", initQueueLengths)
+
+							// Simulate 30 rounds of grading tasks
+							for range 30 {
+
+								// Create a batch of random [1, 5] jobs at a time
+								gradingPayloads := []trigger.GradingPayload{}
+								for range rand.Intn(5) + 1 {
+									gradingPayloads = append(gradingPayloads, trigger.GradingPayload{
+										ID:            testID,
+										ExtractedPath: fmt.Sprintf("extracted/%d", testID),
+										CreatedAt:     time.Now(),
+									})
+								}
+
+								job, err := buildGradingJobPayload("gradingTask", gradingPayloads, testID, false, nil)
+								assert.NoError(t, err, "failed to build grading job payload")
+
+								slog.Info("sending job payload", "payload", string(job))
+								err = s.LoadBalanceGraderPublish(t.Context(), job, len(gradingPayloads))
+								assert.NoError(t, err, "failed to load balance publish")
+
+								slog.Info("grading job scheduled for immediate processing", "submissionID", testID, "assignmentConfigID", testID, "isTest", false)
+
+							}
+
+							// Wait for all processing to complete
+							// Subscribe is already running in the background
+							wg.Add(1)
+							go func() {
+								defer wg.Done()
+
+								// Initial wait before checking
+								time.Sleep(5 * time.Second)
+
+								for {
+									time.Sleep(2 * time.Second)
+									allProcessed := true
+									// Check current lengths
+									for _, channel := range channels {
+										length, err := client.Get(t.Context(), fmt.Sprintf("%s:length", channel)).Int()
+										if err == redis.Nil {
+											length = 0 // Channel does not exist, treat as empty
+										} else if err != nil {
+											slog.Warn("Failed to get length of channel", "channel", channel, "error", err)
+											continue
+										}
+
+										slog.Info("Current channel length", "channel", channel, "length", length)
+										channelProcessed := length <= initQueueLengths[channel]
+										allProcessed = allProcessed && channelProcessed
+									}
+
+									// If all channels are processed, exit the loop
+									if allProcessed {
+										break
+									}
+								}
+
+							}()
+							return nil
+						},
+					})
+				},
+			),
+		)
+
+		app.RequireStart()
+
+		// Wait for processing goroutine to finish
+		wg.Wait()
+
+		t.Cleanup(app.RequireStop)
+	})
+}
+
+func buildGradingJobPayload(jobType string, gradingPayloads []trigger.GradingPayload, assignmentConfigID int, isTest bool, initiatedBy *int) ([]byte, error) {
+	// Build the payload map
+	payloadMap := map[string]interface{}{
+		"submissions":          gradingPayloads,
+		"assignment_config_id": assignmentConfigID,
+		"isTest":               isTest,
+	}
+
+	// Add optional initiatedBy field if provided
+	if initiatedBy != nil {
+		payloadMap["initiatedBy"] = *initiatedBy
+	} else {
+		payloadMap["initiatedBy"] = nil
+	}
+
+	// Marshal the payload
+	payload, err := json.Marshal(payloadMap)
+	if err != nil {
+		slog.Warn("Failed to marshal grading payload", "error", err)
+		return nil, fmt.Errorf("failed to marshal grading payload: %s", err.Error())
+	}
+
+	// Create the job wrapper
+	job, err := json.Marshal(map[string]interface{}{
+		"job":     jobType,
+		"payload": string(payload),
+	})
+	if err != nil {
+		slog.Warn("Failed to marshal job payload", "error", err)
+		return nil, fmt.Errorf("failed to marshal job payload: %s", err.Error())
+	}
+
+	return job, nil
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/rand"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -288,7 +289,7 @@ func TestLoadBalanceIntegration(t *testing.T) {
 			cache.Module,
 			fx.Supply(
 				&cache.Config{
-					DSN: "10.35.53.115:21862",
+					DSN: fmt.Sprintf("%s:%s", os.Getenv("REDIS_HOST"), os.Getenv("REDIS_PORT")),
 				},
 			),
 			fx.Invoke(

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -1,9 +1,14 @@
 package cache_test
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
+	"log/slog"
+	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/go-redis/redis/v8"
 	"github.com/stretchr/testify/assert"
@@ -152,6 +157,100 @@ func TestLoadBalanceDequeue(t *testing.T) {
 					length3, err := client.Get(t.Context(), "channel3:length").Int()
 					assert.NoError(t, err, "failed to get length for channel3")
 					assert.Equal(t, 22, length3)
+				},
+			),
+		)
+
+		app.RequireStart()
+		t.Cleanup(app.RequireStop)
+	})
+}
+
+func TestLoadBalanceIntegration(t *testing.T) {
+	t.Run("publish and dequeue", func(t *testing.T) {
+		app := fxtest.New(
+			t,
+			mock.ProvideMockCacheService(t),
+			fx.Invoke(
+				func(s cache.Service, client *redis.Client) {
+					channels := []string{"channel1", "channel2", "channel3"}
+					s.Put(t.Context(), cache.QueueKey, []byte(strings.Join(channels, ",")), 0)
+
+					s.RegisterHandler("doneGrading", func(ctx context.Context, jobType, queue string, payload json.RawMessage) error {
+						var payloadJson string
+						if err := json.Unmarshal(payload, &payloadJson); err != nil {
+							slog.Warn("Failed to unmarshal payload", "error", err)
+							return err
+						}
+						var data cache.DoneGradingPayload
+						if err := json.Unmarshal([]byte(payloadJson), &data); err != nil {
+							slog.Warn("Failed to unmarshal payload", "error", err)
+							return err
+						}
+						slog.Info("Processing job", "type", jobType, "queue", queue, "payload", data, "is_batch", len(data.Reports) > 1)
+
+						if err := s.LoadBalanceDequeue(ctx, queue, len(data.Reports)); err != nil {
+							slog.Warn("Failed to load balance dequeue", "error", err)
+							return err
+						}
+
+						// Log successful processing
+						var reportIDs []int
+						for _, report := range data.Reports {
+							reportIDs = append(reportIDs, report.ID)
+						}
+						slog.Info("doneGrading processed successfully", "reportIDs", reportIDs, "reportCount", len(data.Reports), "queue", queue)
+
+						return nil
+					})
+
+					go s.Subscribe(t.Context())
+
+					// Publish jobs
+					for i := range 30 {
+						err := s.LoadBalancePublish(t.Context(), channels, []byte(fmt.Sprintf("job%d", i)), 1)
+						assert.NoError(t, err, "failed to load balance publish")
+					}
+
+					donePayloadJsons := make([]cache.DoneGradingPayload, 3)
+					for i := 1; i <= 30; i++ {
+						donePayloadJsons[i%3].Reports = append(donePayloadJsons[i%3].Reports,
+							struct {
+								ID           int `json:"id"`
+								SubmissionID int `json:"submission_id"`
+							}{ID: i, SubmissionID: i})
+					}
+
+					for idx, channel := range channels {
+						donePayload, err := json.Marshal(donePayloadJsons[idx])
+						assert.NoError(t, err, "failed to marshal done grading payload")
+
+						donePayloadStr, err := json.Marshal(string(donePayload))
+						assert.NoError(t, err, "failed to marshal done grading payload string")
+
+						msg := cache.JobMessage{
+							Job:     "doneGrading",
+							Payload: donePayloadStr,
+						}
+						msgPayload, err := json.Marshal(msg)
+						assert.NoError(t, err, "failed to marshal done message")
+						err = client.LPush(t.Context(), fmt.Sprintf("%s:api", channel), msgPayload).Err()
+						assert.NoError(t, err, "failed to push done message to channel %s", channel)
+					}
+
+					// Allow some time for processing
+					t.Log("Waiting for jobs to be processed... (19s)")
+					time.Sleep(19 * time.Second)
+					t.Log("Finished waiting")
+
+					// Check that all jobs have been processed and queues are empty
+					for _, channel := range channels {
+						length, err := client.Get(t.Context(), fmt.Sprintf("%s:length", channel)).Int()
+						assert.NoError(t, err, "failed to get length for %s", channel)
+						assert.Equal(t, 0, length)
+					}
+
+					// cancelCtx()
 				},
 			),
 		)

--- a/pkg/cache/service.go
+++ b/pkg/cache/service.go
@@ -200,13 +200,10 @@ func (s *service) Subscribe(ctx context.Context) error {
 				time.Sleep(5 * time.Second)
 				continue
 			}
-			var queues []string
-			for _, queue := range strings.Split(string(data), ",") {
-				queues = append(queues, fmt.Sprintf("%s:api", queue))
-			}
+			queues := strings.Split(string(data), ",")
 
 			for _, queue := range queues {
-				result, err := s.client.BRPop(ctx, 5*time.Second, queue).Result()
+				result, err := s.client.BRPop(ctx, 5*time.Second, fmt.Sprintf("%s:api", queue)).Result()
 				if err != nil {
 					if err == redis.Nil {
 						// No message available, continue polling

--- a/pkg/cache/service.go
+++ b/pkg/cache/service.go
@@ -54,7 +54,8 @@ type Service interface {
 	Read(ctx context.Context, key string) ([]byte, error)
 	Remove(ctx context.Context, key string) error
 	Publish(ctx context.Context, channel string, message []byte) error
-	LoadBalancePublish(ctx context.Context, channels []string, message []byte) error
+	LoadBalancePublish(ctx context.Context, channels []string, message []byte, njobs int) error
+	LoadBalanceDequeue(ctx context.Context, channel string, njobs int) error
 	Llen(ctx context.Context, channel string) (int64, error)
 	Subscribe(ctx context.Context) error
 	RegisterHandler(jobType string, handler MessageHandler)
@@ -121,17 +122,19 @@ func (s *service) Publish(ctx context.Context, channel string, message []byte) e
 	return s.client.RPush(ctx, channel, message).Err()
 }
 
-func (s *service) LoadBalancePublish(ctx context.Context, channels []string, message []byte) error {
+func (s *service) LoadBalancePublish(ctx context.Context, channels []string, message []byte, njobs int) error {
 
 	s.locker.Lock()
 	defer s.locker.Unlock()
 
 	// Find the channel with the least number of messages
 	var targetChannel string
-	minLen := int64(-1)
+	minLen := -1
 	for _, channel := range channels {
-		length, err := s.Llen(ctx, channel)
-		if err != nil {
+		length, err := s.client.Get(ctx, fmt.Sprintf("%s:length", channel)).Int()
+		if err == redis.Nil {
+			length = 0 // Channel does not exist, treat as empty
+		} else if err != nil {
 			slog.Warn("Failed to get length of channel", "channel", channel, "error", err)
 			continue
 		}
@@ -145,7 +148,34 @@ func (s *service) LoadBalancePublish(ctx context.Context, channels []string, mes
 		return fmt.Errorf("failed to determine target channel for load balancing")
 	}
 	slog.Info("Publishing to channel: %s with %d messages", "channel", targetChannel, "length", minLen)
-	return s.client.RPush(ctx, targetChannel, message).Err()
+
+	pipe := s.client.TxPipeline()
+	pipe.RPush(ctx, targetChannel, message)
+	pipe.IncrBy(ctx, fmt.Sprintf("%s:length", targetChannel), int64(njobs))
+
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+func (s *service) LoadBalanceDequeue(ctx context.Context, channel string, njobs int) error {
+	s.locker.Lock()
+	defer s.locker.Unlock()
+
+	err := s.client.DecrBy(ctx, fmt.Sprintf("%s:length", channel), int64(njobs)).Err()
+	if err != nil {
+		return err
+	}
+
+	curr_len, err := s.client.Get(ctx, fmt.Sprintf("%s:length", channel)).Int()
+	if err != nil {
+		return err
+	}
+	if curr_len < 0 {
+		// Reset to zero if it goes negative
+		slog.Warn("Channel length went negative, resetting to zero", "channel", channel)
+		return s.client.Set(ctx, fmt.Sprintf("%s:length", channel), 0, 0).Err()
+	}
+	return nil
 }
 
 func (s *service) Subscribe(ctx context.Context) error {

--- a/pkg/cache/service.go
+++ b/pkg/cache/service.go
@@ -54,9 +54,9 @@ type Service interface {
 	Read(ctx context.Context, key string) ([]byte, error)
 	Remove(ctx context.Context, key string) error
 	Publish(ctx context.Context, channel string, message []byte) error
-	LoadBalancePublish(ctx context.Context, channels []string, message []byte, njobs int) error
-	LoadBalanceDequeue(ctx context.Context, channel string, njobs int) error
 	Llen(ctx context.Context, channel string) (int64, error)
+	LoadBalanceGraderPublish(ctx context.Context, message []byte, njobs int) error
+	LoadBalanceGraderDequeue(ctx context.Context, channel string, njobs int) error
 	Subscribe(ctx context.Context) error
 	RegisterHandler(jobType string, handler MessageHandler)
 }
@@ -122,20 +122,42 @@ func (s *service) Publish(ctx context.Context, channel string, message []byte) e
 	return s.client.RPush(ctx, channel, message).Err()
 }
 
-func (s *service) LoadBalancePublish(ctx context.Context, channels []string, message []byte, njobs int) error {
+func (s *service) LoadBalanceGraderPublish(ctx context.Context, message []byte, njobs int) error {
 
 	s.locker.Lock()
 	defer s.locker.Unlock()
 
+	data, err := s.Read(ctx, QueueKey)
+	if err != nil {
+		slog.Warn("Failed to read grader queues", "error", err)
+		return fmt.Errorf("failed to read grader queues: %s", err.Error())
+	}
+	if data == nil {
+		return fmt.Errorf("no grader queues configured")
+	}
+
+	channels := strings.Split(string(data), ",")
+
+	// Transaction for atomicity on getting lengths
+	trans := s.client.TxPipeline()
+	for _, channel := range channels {
+		trans.Get(ctx, fmt.Sprintf("%s:length", channel))
+	}
+	cmds, err := trans.Exec(ctx)
+	if err != nil && err != redis.Nil {
+		return fmt.Errorf("failed to get lengths of channels: %s", err.Error())
+	}
+
 	// Find the channel with the least number of messages
 	var targetChannel string
 	minLen := -1
-	for _, channel := range channels {
-		length, err := s.client.Get(ctx, fmt.Sprintf("%s:length", channel)).Int()
+
+	for idx, channel := range channels {
+		length, err := cmds[idx].(*redis.StringCmd).Int()
 		if err == redis.Nil {
 			length = 0 // Channel does not exist, treat as empty
 		} else if err != nil {
-			slog.Warn("Failed to get length of channel", "channel", channel, "error", err)
+			slog.Warn("Failed to get value of of key", "key", fmt.Sprintf("%s:length", channel), "error", err)
 			continue
 		}
 		if minLen == -1 || length < minLen {
@@ -144,23 +166,24 @@ func (s *service) LoadBalancePublish(ctx context.Context, channels []string, mes
 		}
 	}
 
+	targetGraderChannel := fmt.Sprintf("%s:grader", targetChannel)
 	if minLen < 0 {
 		return fmt.Errorf("failed to determine target channel for load balancing")
 	}
-	slog.Info("Publishing to channel: %s with %d messages", "channel", targetChannel, "length", minLen)
+	slog.Info("Publishing to channel: %s with %d messages", "channel", targetGraderChannel, "length", minLen)
 
-	pipe := s.client.TxPipeline()
-	pipe.RPush(ctx, targetChannel, message)
-	pipe.IncrBy(ctx, fmt.Sprintf("%s:length", targetChannel), int64(njobs))
+	trans = s.client.TxPipeline()
+	trans.RPush(ctx, targetGraderChannel, message)
+	trans.IncrBy(ctx, fmt.Sprintf("%s:length", targetChannel), int64(njobs))
 
-	_, err := pipe.Exec(ctx)
+	_, err = trans.Exec(ctx)
 	if err == nil {
-		slog.Info("successfully published to queue", "targetChannel", targetChannel, "queueLength", minLen+njobs, "messageSize", len(message))
+		slog.Info("successfully published to queue", "queue", targetGraderChannel, "queueLength", minLen+njobs, "messageSize", len(message))
 	}
 	return err
 }
 
-func (s *service) LoadBalanceDequeue(ctx context.Context, channel string, njobs int) error {
+func (s *service) LoadBalanceGraderDequeue(ctx context.Context, channel string, njobs int) error {
 	s.locker.Lock()
 	defer s.locker.Unlock()
 
@@ -182,6 +205,7 @@ func (s *service) LoadBalanceDequeue(ctx context.Context, channel string, njobs 
 }
 
 func (s *service) Subscribe(ctx context.Context) error {
+	slog.Info("Starting cache subscriber...")
 	for {
 		select {
 		case <-ctx.Done():

--- a/pkg/cache/service.go
+++ b/pkg/cache/service.go
@@ -154,7 +154,7 @@ func (s *service) LoadBalancePublish(ctx context.Context, channels []string, mes
 	pipe.IncrBy(ctx, fmt.Sprintf("%s:length", targetChannel), int64(njobs))
 
 	_, err := pipe.Exec(ctx)
-  if err == nil {
+	if err == nil {
 		slog.Info("successfully published to queue", "targetChannel", targetChannel, "queueLength", minLen+njobs, "messageSize", len(message))
 	}
 	return err

--- a/pkg/mock/mock.go
+++ b/pkg/mock/mock.go
@@ -8,12 +8,14 @@ import (
 	"testing"
 	"time"
 
+	"github.com/go-redis/redis/v8"
 	"github.com/golang-jwt/jwt/v4"
 	"github.com/machinebox/graphql"
 	container "github.com/narwhl/mockestra/redis"
 	"github.com/stretchr/testify/mock"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/zinc-sig/webhook/pkg/cache"
+	"github.com/zinc-sig/webhook/pkg/repository"
 	"go.uber.org/fx"
 )
 
@@ -25,6 +27,122 @@ type MockGraphQLClient struct {
 func (m *MockGraphQLClient) Run(ctx context.Context, req *graphql.Request, resp interface{}) error {
 	args := m.Called(ctx, req, resp)
 	return args.Error(0)
+}
+
+type MockRepository struct {
+	mock.Mock
+}
+
+func (m *MockRepository) GetUser(ctx context.Context, itsc, name string) (*repository.User, error) {
+	args := m.Called(ctx, itsc, name)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*repository.User), args.Error(1)
+}
+
+func (m *MockRepository) UpdateExtractedSubmissionEntry(ctx context.Context, id int, extractedPath, failReason string) error {
+	args := m.Called(ctx, id, extractedPath, failReason)
+	return args.Error(0)
+}
+
+func (m *MockRepository) AddCourse(ctx context.Context, code string, semesterID int, title string) (int, error) {
+	args := m.Called(ctx, code, semesterID, title)
+	return args.Int(0), args.Error(1)
+}
+
+func (m *MockRepository) AddSections(ctx context.Context, courseID int, sectionNames []string) (map[string]int, error) {
+	args := m.Called(ctx, courseID, sectionNames)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(map[string]int), args.Error(1)
+}
+
+func (m *MockRepository) AddStudentsToCourseSection(ctx context.Context, studentUserIDs []int, sectionID int) error {
+	args := m.Called(ctx, studentUserIDs, sectionID)
+	return args.Error(0)
+}
+
+func (m *MockRepository) AddStudentsToCourse(ctx context.Context, studentUserIDs []int, courseID int) error {
+	args := m.Called(ctx, studentUserIDs, courseID)
+	return args.Error(0)
+}
+
+func (m *MockRepository) RemoveStudentsFromCourse(ctx context.Context, courseID int) error {
+	args := m.Called(ctx, courseID)
+	return args.Error(0)
+}
+
+func (m *MockRepository) RemoveStudentsFromSection(ctx context.Context, sectionID int) error {
+	args := m.Called(ctx, sectionID)
+	return args.Error(0)
+}
+
+func (m *MockRepository) GetStudentUserIds(ctx context.Context, itscIDs []string) ([]int, error) {
+	args := m.Called(ctx, itscIDs)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]int), args.Error(1)
+}
+
+func (m *MockRepository) CreateSemesterIfNotExist(ctx context.Context, id int) error {
+	args := m.Called(ctx, id)
+	return args.Error(0)
+}
+
+func (m *MockRepository) GetStudentCourseEnrollmentMap(courseCode string) (*repository.EnrollmentMap, error) {
+	args := m.Called(courseCode)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*repository.EnrollmentMap), args.Error(1)
+}
+
+func (m *MockRepository) UpdateReportEntry(ctx context.Context, report map[string]interface{}) error {
+	args := m.Called(ctx, report)
+	return args.Error(0)
+}
+
+func (m *MockRepository) GetGradingSubmissions(ctx context.Context, assignmentConfigID int) (*repository.Assignment, error) {
+	args := m.Called(ctx, assignmentConfigID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).(*repository.Assignment), args.Error(1)
+}
+
+func (m *MockRepository) GetLatestOrSelectedSubmissions(ctx context.Context, assignmentConfigID int, selectedSubmissionIDs []int) ([]repository.Submission, error) {
+	args := m.Called(ctx, assignmentConfigID, selectedSubmissionIDs)
+	if args.Get(0) == nil {
+		return nil, args.Error(1)
+	}
+	return args.Get(0).([]repository.Submission), args.Error(1)
+}
+
+func (m *MockRepository) ExtractZip(submissionID int, storedName string) error {
+	args := m.Called(submissionID, storedName)
+	return args.Error(0)
+}
+
+func (m *MockRepository) GetGradingPolicy(ctx context.Context, assignmentConfigID, userID int) (bool, bool, error) {
+	args := m.Called(ctx, assignmentConfigID, userID)
+	return args.Bool(0), args.Bool(1), args.Error(2)
+}
+
+func ProvideMockRepository(t *testing.T) fx.Option {
+	mockRepo := new(MockRepository)
+	return fx.Options(
+		fx.NopLogger,
+		fx.Supply(mockRepo),
+		fx.Supply(
+			fx.Annotate(
+				mockRepo,
+				fx.As(new(repository.Repository)),
+			),
+		),
+	)
 }
 
 func ProvideMockCacheService(t *testing.T) fx.Option {
@@ -53,8 +171,22 @@ func ProvideMockCacheService(t *testing.T) fx.Option {
 				DSN: endpoint,
 			}
 		}),
+		// Cache Service
 		fx.Provide(
 			cache.NewService,
+		),
+		// Redis Client
+		fx.Provide(
+			func(p struct {
+				fx.In
+				Config *cache.Config
+			}) *redis.Client {
+				return redis.NewClient(&redis.Options{
+					Addr:     p.Config.DSN, // e.g., "localhost:6379"
+					Password: "",           // no password set
+					DB:       0,            // use default DB
+				})
+			},
 		),
 	)
 }

--- a/pkg/trigger/service.go
+++ b/pkg/trigger/service.go
@@ -322,27 +322,31 @@ func (s *service) ManualGradingTask(ctx context.Context, assignmentConfigId int,
 		return fmt.Errorf("failed to get submissions: %s", err.Error())
 	}
 
-	var gradingPayloads []GradingPayload
-
+	// Decompose submissions in a batch and send to grader one by one for load balancing
 	for _, submission := range submissions {
-		gradingPayloads = append(gradingPayloads, GradingPayload{
-			ID:            submission.ID,
-			ExtractedPath: submission.ExtractedPath,
-			CreatedAt:     submission.CreatedAt.Time(),
-		})
+
+		gradingPayloads := []GradingPayload{
+			{
+				ID:            submission.ID,
+				ExtractedPath: submission.ExtractedPath,
+				CreatedAt:     submission.CreatedAt.Time(),
+			},
+		}
+
+		// Build job payload
+		jsonPayload, err := s.buildGradingJobPayload("manualGradingTask", gradingPayloads, assignmentConfigId, false, &req.InitiatedBy)
+		if err != nil {
+			return err
+		}
+		slog.Info("sending job payload", "payload", string(jsonPayload))
+		if err := s.cache.LoadBalanceGraderPublish(ctx, jsonPayload, len(gradingPayloads)); err != nil {
+			slog.Warn("Failed to publish grading payload", "error", err)
+			return fmt.Errorf("failed to publish grading payload: %s", err.Error())
+		}
+
 	}
 
-	// Build job payload
-	jsonPayload, err := s.buildGradingJobPayload("manualGradingTask", gradingPayloads, assignmentConfigId, false, &req.InitiatedBy)
-	if err != nil {
-		return err
-	}
-	slog.Info("sending job payload", "payload", string(jsonPayload))
-	if err := s.cache.LoadBalanceGraderPublish(ctx, jsonPayload, len(gradingPayloads)); err != nil {
-		slog.Warn("Failed to publish grading payload", "error", err)
-		return fmt.Errorf("failed to publish grading payload: %s", err.Error())
-	}
-	slog.Info("manual grading task scheduled", "assignmentConfigID", assignmentConfigId, "submissionCount", len(gradingPayloads), "initiatedBy", req.InitiatedBy)
+	slog.Info("manual grading task scheduled", "assignmentConfigID", assignmentConfigId, "submissionCount", len(submissions), "initiatedBy", req.InitiatedBy)
 	return nil
 }
 
@@ -354,26 +358,31 @@ func (s *service) GradingTask(ctx context.Context, payload *GradingTaskRequest) 
 	}
 
 	if *submissions.AssignmentConfig.StopCollectionAt == payload.Payload.StopCollectionAt {
-		// Push job to redis
-		gradingPayloads := make([]GradingPayload, 0, len(submissions.AssignmentConfig.Submissions))
+		// Decompose submissions in a batch and send to grader one by one for load balancing
 		for _, submission := range submissions.AssignmentConfig.Submissions {
-			gradingPayloads = append(gradingPayloads, GradingPayload{
-				ID:            submission.ID,
-				ExtractedPath: submission.ExtractedPath,
-				CreatedAt:     submission.CreatedAt.Time(),
-			})
+
+			gradingPayloads := []GradingPayload{
+				{
+					ID:            submission.ID,
+					ExtractedPath: submission.ExtractedPath,
+					CreatedAt:     submission.CreatedAt.Time(),
+				},
+			}
+
+			// Build job payload
+			jsonPayload, err := s.buildGradingJobPayload("gradingTask", gradingPayloads, payload.Payload.AssignmentConfigID, false, nil)
+			if err != nil {
+				return err
+			}
+			slog.Info("sending job payload", "payload", string(jsonPayload))
+			if err := s.cache.LoadBalanceGraderPublish(ctx, jsonPayload, len(gradingPayloads)); err != nil {
+				slog.Warn("Failed to publish grading payload", "error", err)
+				return fmt.Errorf("failed to publish grading payload: %s", err.Error())
+			}
+
 		}
-		// Build job payload
-		jsonPayload, err := s.buildGradingJobPayload("gradingTask", gradingPayloads, payload.Payload.AssignmentConfigID, false, nil)
-		if err != nil {
-			return err
-		}
-		slog.Info("sending job payload", "payload", string(jsonPayload))
-		if err := s.cache.LoadBalanceGraderPublish(ctx, jsonPayload, len(gradingPayloads)); err != nil {
-			slog.Warn("Failed to publish grading payload", "error", err)
-			return fmt.Errorf("failed to publish grading payload: %s", err.Error())
-		}
-		slog.Info("grading task scheduled for batch processing", "assignmentConfigID", payload.Payload.AssignmentConfigID, "submissionCount", len(gradingPayloads), "stopCollectionAt", payload.Payload.StopCollectionAt)
+
+		slog.Info("grading task scheduled for processing", "assignmentConfigID", payload.Payload.AssignmentConfigID, "submissionCount", len(submissions.AssignmentConfig.Submissions), "stopCollectionAt", payload.Payload.StopCollectionAt)
 	}
 	return nil
 }

--- a/pkg/trigger/service.go
+++ b/pkg/trigger/service.go
@@ -216,20 +216,8 @@ func (s *service) DecompressSubmission(ctx context.Context, payload json.RawMess
 		if err != nil {
 			return err
 		}
-		data, err := s.cache.Read(ctx, cache.QueueKey)
-		if err != nil {
-			slog.Warn("Failed to read grader queues", "error", err)
-			return fmt.Errorf("failed to read grader queues: %s", err.Error())
-		}
-		if data == nil {
-			return fmt.Errorf("no grader queues configured")
-		}
-		var queues []string
-		for _, queue := range strings.Split(string(data), ",") {
-			queues = append(queues, fmt.Sprintf("%s:grader", queue))
-		}
 		slog.Info("sending job payload", "payload", string(job))
-		if err := s.cache.LoadBalancePublish(ctx, queues, job, len(gradingPayloads)); err != nil {
+		if err := s.cache.LoadBalanceGraderPublish(ctx, job, len(gradingPayloads)); err != nil {
 			slog.Warn("Failed to publish grading payload", "error", err)
 			return fmt.Errorf("failed to publish grading payload: %s", err.Error())
 		}
@@ -349,21 +337,8 @@ func (s *service) ManualGradingTask(ctx context.Context, assignmentConfigId int,
 	if err != nil {
 		return err
 	}
-
-	data, err := s.cache.Read(ctx, cache.QueueKey)
-	if err != nil {
-		slog.Warn("Failed to read grader queues", "error", err)
-		return fmt.Errorf("failed to read grader queues: %s", err.Error())
-	}
-	if data == nil {
-		return fmt.Errorf("no grader queues configured")
-	}
-	var queues []string
-	for _, queue := range strings.Split(string(data), ",") {
-		queues = append(queues, fmt.Sprintf("%s:grader", queue))
-	}
 	slog.Info("sending job payload", "payload", string(jsonPayload))
-	if err := s.cache.LoadBalancePublish(ctx, queues, jsonPayload, len(gradingPayloads)); err != nil {
+	if err := s.cache.LoadBalanceGraderPublish(ctx, jsonPayload, len(gradingPayloads)); err != nil {
 		slog.Warn("Failed to publish grading payload", "error", err)
 		return fmt.Errorf("failed to publish grading payload: %s", err.Error())
 	}
@@ -393,20 +368,8 @@ func (s *service) GradingTask(ctx context.Context, payload *GradingTaskRequest) 
 		if err != nil {
 			return err
 		}
-		data, err := s.cache.Read(ctx, cache.QueueKey)
-		if err != nil {
-			slog.Warn("Failed to read grader queues", "error", err)
-			return fmt.Errorf("failed to read grader queues: %s", err.Error())
-		}
-		if data == nil {
-			return fmt.Errorf("no grader queues configured")
-		}
-		var queues []string
-		for _, queue := range strings.Split(string(data), ",") {
-			queues = append(queues, fmt.Sprintf("%s:grader", queue))
-		}
 		slog.Info("sending job payload", "payload", string(jsonPayload))
-		if err := s.cache.LoadBalancePublish(ctx, queues, jsonPayload, len(gradingPayloads)); err != nil {
+		if err := s.cache.LoadBalanceGraderPublish(ctx, jsonPayload, len(gradingPayloads)); err != nil {
 			slog.Warn("Failed to publish grading payload", "error", err)
 			return fmt.Errorf("failed to publish grading payload: %s", err.Error())
 		}

--- a/pkg/trigger/service.go
+++ b/pkg/trigger/service.go
@@ -57,21 +57,21 @@ func (s *service) buildGradingJobPayload(jobType string, gradingPayloads []Gradi
 		"assignment_config_id": assignmentConfigID,
 		"isTest":               isTest,
 	}
-	
+
 	// Add optional initiatedBy field if provided
 	if initiatedBy != nil {
 		payloadMap["initiatedBy"] = *initiatedBy
 	} else {
 		payloadMap["initiatedBy"] = nil
 	}
-	
+
 	// Marshal the payload
 	payload, err := json.Marshal(payloadMap)
 	if err != nil {
 		slog.Warn("Failed to marshal grading payload", "error", err)
 		return nil, fmt.Errorf("failed to marshal grading payload: %s", err.Error())
 	}
-	
+
 	// Create the job wrapper
 	job, err := json.Marshal(map[string]interface{}{
 		"job":     jobType,
@@ -81,7 +81,7 @@ func (s *service) buildGradingJobPayload(jobType string, gradingPayloads []Gradi
 		slog.Warn("Failed to marshal job payload", "error", err)
 		return nil, fmt.Errorf("failed to marshal job payload: %s", err.Error())
 	}
-	
+
 	return job, nil
 }
 
@@ -207,7 +207,7 @@ func (s *service) DecompressSubmission(ctx context.Context, payload json.RawMess
 				CreatedAt:     submission.CreatedAt.Time(),
 			},
 		}
-		
+
 		job, err := s.buildGradingJobPayload("gradingTask", gradingPayloads, submission.AssignmentConfigID, isTest, nil)
 		if err != nil {
 			return err
@@ -225,7 +225,7 @@ func (s *service) DecompressSubmission(ctx context.Context, payload json.RawMess
 			queues = append(queues, fmt.Sprintf("%s:grader", queue))
 		}
 		slog.Info("sending job payload", "payload", string(job))
-		if err := s.cache.LoadBalancePublish(ctx, queues, job); err != nil {
+		if err := s.cache.LoadBalancePublish(ctx, queues, job, len(gradingPayloads)); err != nil {
 			slog.Warn("Failed to publish grading payload", "error", err)
 			return fmt.Errorf("failed to publish grading payload: %s", err.Error())
 		}
@@ -360,7 +360,7 @@ func (s *service) ManualGradingTask(ctx context.Context, assignmentConfigId int,
 		queues = append(queues, fmt.Sprintf("%s:grader", queue))
 	}
 	slog.Info("sending job payload", "payload", string(jsonPayload))
-	if err := s.cache.LoadBalancePublish(ctx, queues, jsonPayload); err != nil {
+	if err := s.cache.LoadBalancePublish(ctx, queues, jsonPayload, len(gradingPayloads)); err != nil {
 		slog.Warn("Failed to publish grading payload", "error", err)
 		return fmt.Errorf("failed to publish grading payload: %s", err.Error())
 	}
@@ -402,7 +402,7 @@ func (s *service) GradingTask(ctx context.Context, payload *GradingTaskRequest) 
 			queues = append(queues, fmt.Sprintf("%s:grader", queue))
 		}
 		slog.Info("sending job payload", "payload", string(jsonPayload))
-		if err := s.cache.LoadBalancePublish(ctx, queues, jsonPayload); err != nil {
+		if err := s.cache.LoadBalancePublish(ctx, queues, jsonPayload, len(gradingPayloads)); err != nil {
 			slog.Warn("Failed to publish grading payload", "error", err)
 			return fmt.Errorf("failed to publish grading payload: %s", err.Error())
 		}

--- a/pkg/user/handler_test.go
+++ b/pkg/user/handler_test.go
@@ -47,12 +47,12 @@ func (m *MockCache) Publish(ctx context.Context, channel string, message []byte)
 	return args.Error(0)
 }
 
-func (m *MockCache) LoadBalancePublish(ctx context.Context, channels []string, message []byte, njobs int) error {
-	args := m.Called(ctx, channels, message, njobs)
+func (m *MockCache) LoadBalanceGraderPublish(ctx context.Context, message []byte, njobs int) error {
+	args := m.Called(ctx, message, njobs)
 	return args.Error(0)
 }
 
-func (m *MockCache) LoadBalanceDequeue(ctx context.Context, channel string, njobs int) error {
+func (m *MockCache) LoadBalanceGraderDequeue(ctx context.Context, channel string, njobs int) error {
 	args := m.Called(ctx, channel, njobs)
 	return args.Error(0)
 }

--- a/pkg/user/handler_test.go
+++ b/pkg/user/handler_test.go
@@ -47,8 +47,13 @@ func (m *MockCache) Publish(ctx context.Context, channel string, message []byte)
 	return args.Error(0)
 }
 
-func (m *MockCache) LoadBalancePublish(ctx context.Context, channels []string, message []byte) error {
-	args := m.Called(ctx, channels, message)
+func (m *MockCache) LoadBalancePublish(ctx context.Context, channels []string, message []byte, njobs int) error {
+	args := m.Called(ctx, channels, message, njobs)
+	return args.Error(0)
+}
+
+func (m *MockCache) LoadBalanceDequeue(ctx context.Context, channel string, njobs int) error {
+	args := m.Called(ctx, channel, njobs)
 	return args.Error(0)
 }
 


### PR DESCRIPTION
- Add test on testing the `LoadBalancePublish` communication between webhook & graders in the staging environment.
- The `LoadBalancePublish` function no longer accepts the `[]string channels` parameter. It will now fetch the existing grader channels from Redis instead.
- Modified logic on calling `LoadBalancePublish` in trigger/service.go. For batch jobs, it will now decompose every submission in a batch to use the load-balancing feature to send to graders for better efficiency.