### PR TITLE
feat(mock): add Hasura container management and simulation command

### DIFF
--- a/cmd/simulate.go
+++ b/cmd/simulate.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/narwhl/mockestra"
+	"github.com/narwhl/mockestra/postgres"
+	"github.com/narwhl/mockestra/redis"
+	"github.com/spf13/cobra"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/zinc-sig/webhook/pkg/mock"
+	"go.uber.org/fx"
+)
+
+func NewSimulation() *fx.App {
+	defaultModules := []fx.Option{
+		fx.NopLogger,
+		fx.Supply(
+			fx.Annotate(
+				fmt.Sprintf("%x", time.Now().Unix()),
+				fx.ResultTags(`name:"prefix"`),
+			),
+		),
+		postgres.Module(
+			postgres.WithPassword("zinc"),
+			postgres.WithUsername("zinc"),
+			postgres.WithDatabase("zinc"),
+			postgres.WithMigration(func(dsn string) error {
+				return ApplyMigrations(dsn)
+			}),
+		),
+		redis.Module(),
+		mock.HasuraModule(
+			mock.WithAdminSecret("zincsecret"),
+		),
+		fx.Invoke(func(p struct {
+			fx.In
+			Lifecycle  fx.Lifecycle
+			Containers []testcontainers.Container `group:"containers"`
+		}) {
+			p.Lifecycle.Append(fx.Hook{
+				OnStart: func(ctx context.Context) error {
+					slog.Info("ZINC Simulation Started")
+					return nil
+				},
+				OnStop: func(ctx context.Context) error {
+					slog.Info("Stopping ZINC Simulation...")
+					return nil
+				},
+			})
+		}),
+	}
+
+	defaultModules = append(defaultModules, mockestra.Versions(map[string]string{
+		"postgres": "17-alpine",
+		"redis":    "8-alpine",
+		"hasura":   "v2.48.0",
+	})...)
+
+	return fx.New(defaultModules...)
+}
+
+var simulateCmd = &cobra.Command{
+	Use:   "simulate",
+	Short: "simulates the stack",
+	Run: func(cmd *cobra.Command, args []string) {
+		app := NewSimulation()
+		app.Run()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(simulateCmd)
+}

--- a/pkg/mock/hasura.go
+++ b/pkg/mock/hasura.go
@@ -1,0 +1,142 @@
+package mock
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/narwhl/mockestra"
+	"github.com/testcontainers/testcontainers-go"
+	"github.com/testcontainers/testcontainers-go/wait"
+	"github.com/zinc-sig/webhook/pkg/api"
+	"go.uber.org/fx"
+)
+
+const (
+	Port  = "8080/tcp"
+	Tag   = "hasura"
+	Image = "hasura/graphql-engine"
+)
+
+func WithPostgres(dsn string) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		req.Env["HASURA_GRAPHQL_DATABASE_URL"] = dsn
+		req.Env["HASURA_GRAPHQL_METADATA_DATABASE_URL"] = dsn
+		req.Env["PG_DATABASE_URL"] = dsn
+		return nil
+	}
+}
+
+func WithAdminSecret(secret string) testcontainers.CustomizeRequestOption {
+	return func(req *testcontainers.GenericContainerRequest) error {
+		req.Env["HASURA_GRAPHQL_ADMIN_SECRET"] = secret
+		return nil
+	}
+}
+
+type RequestParams struct {
+	fx.In
+	Prefix  string                               `name:"prefix"`
+	Version string                               `name:"hasura_version"`
+	Opts    []testcontainers.ContainerCustomizer `group:"hasura"`
+}
+
+func New(p RequestParams) (*testcontainers.GenericContainerRequest, error) {
+
+	r := testcontainers.GenericContainerRequest{
+		ContainerRequest: testcontainers.ContainerRequest{
+			Name:            fmt.Sprintf("mock-%s-%s", p.Prefix, Tag),
+			Image:           fmt.Sprintf("%s:%s", Image, p.Version),
+			ExposedPorts:    []string{Port},
+			HostAccessPorts: []int{api.Port},
+			WaitingFor:      wait.ForHTTP("/healthz").WithPort(Port),
+			Env: map[string]string{
+				"HASURA_GRAPHQL_VERSION":        "3",
+				"HASURA_GRAPHQL_ENABLE_CONSOLE": "true",
+				"HASURA_GRAPHQL_AUTH_HOOK":      fmt.Sprintf("http://host.docker.internal:%d/identity", api.Port),
+				"HASURA_GRAPHQL_AUTH_HOOK_MODE": "POST",
+			},
+		},
+		Started: true,
+	}
+
+	for _, opt := range p.Opts {
+		if err := opt.Customize(&r); err != nil {
+			return nil, err
+		}
+	}
+	return &r, nil
+}
+
+type ContainerParams struct {
+	fx.In
+	Lifecycle                fx.Lifecycle
+	Request                  *testcontainers.GenericContainerRequest `name:"hasura"`
+	PostgresContainerRequest *testcontainers.GenericContainerRequest `name:"postgres"`
+	PostgresContainer        testcontainers.Container                `name:"postgres"`
+}
+
+type Result struct {
+	fx.Out
+	Container      testcontainers.Container `name:"hasura"`
+	ContainerGroup testcontainers.Container `group:"containers"`
+}
+
+func Actualize(p ContainerParams) (Result, error) {
+	postgresIP, err := p.PostgresContainer.ContainerIP(context.Background())
+	if err != nil {
+		return Result{}, fmt.Errorf("failed to get Postgres container IP: %w", err)
+	}
+	WithPostgres(
+		fmt.Sprintf(
+			"postgres://%s:%s@%s/%s",
+			p.PostgresContainerRequest.Env["POSTGRES_USER"],
+			p.PostgresContainerRequest.Env["POSTGRES_PASSWORD"],
+			postgresIP,
+			p.PostgresContainerRequest.Env["POSTGRES_DB"],
+		),
+	).Customize(p.Request)
+	c, err := testcontainers.GenericContainer(context.Background(), *p.Request)
+	if err != nil {
+		return Result{}, fmt.Errorf("an error occurred while instantiating Hasura container: %w", err)
+	}
+
+	p.Lifecycle.Append(fx.Hook{
+		OnStart: func(ctx context.Context) error {
+			hasuraPort, err := c.MappedPort(ctx, Port)
+			if err != nil {
+				return fmt.Errorf("unable to get %s port: %w", Tag, err)
+			}
+
+			slog.Info(
+				fmt.Sprintf("%s container is running", Tag),
+				"addr", fmt.Sprintf("localhost:%s", hasuraPort.Port()),
+			)
+			return nil
+		},
+		OnStop: func(ctx context.Context) error {
+			err := c.Terminate(ctx)
+			if err != nil {
+				slog.Warn(fmt.Sprintf("an error occurred while terminating %s container", Tag), "error", err)
+			} else {
+				slog.Info(fmt.Sprintf("%s container is terminated", Tag))
+			}
+			return err
+		},
+	})
+	return Result{
+		Container:      c,
+		ContainerGroup: c,
+	}, nil
+}
+
+var HasuraModule = mockestra.BuildContainerModule(
+	Tag,
+	fx.Provide(
+		fx.Annotate(
+			New,
+			fx.ResultTags(`name:"hasura"`),
+		),
+		Actualize,
+	),
+)


### PR DESCRIPTION
This pull request introduces a new simulation command and a mock Hasura container module to the project. The main goals are to enable local simulation of the application stack (including Postgres, Redis, and Hasura) and to provide a reusable Hasura container setup for testing and development.

**Simulation command and stack orchestration:**

* Adds a new `cmd/simulate.go` file that defines a `simulate` Cobra command, which launches a local stack using Fx modules for Postgres, Redis, and Hasura, with versioning and lifecycle logging. (`cmd/simulate.go`, [cmd/simulate.goR1-R77](diffhunk://#diff-77d333b91263a20bcda517fce85ab2e2ae7653c15f05c8ab87f283adbc1e7c7fR1-R77))

**Mock Hasura container module:**

* Introduces `pkg/mock/hasura.go`, which implements a Hasura container module for Fx, including:
  - Customization options for Postgres connection and admin secret.
  - Container request and lifecycle management, including startup and shutdown hooks with logging.
  - Integration with testcontainers and mockestra for container orchestration. (`pkg/mock/hasura.go`, [pkg/mock/hasura.goR1-R142](diffhunk://#diff-03ae8bc39463ceb94233d1bc65f21320d16c717076f36f0a82a556c99884f66bR1-R142))